### PR TITLE
docs: Describe Git branch naming convention

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -17,6 +17,7 @@ This is the documentation for the affiliations service. We follow the
   - [Organize imports and constants](./howto.md#organize-imports-and-constants)
   - [Write a TODO comment](./howto.md#write-a-todo-comment)
   - [Write a commit message](./howto.md#write-a-commit-message)
+  - [Name a Git branch](./howto.md#name-a-git-branch)
 - [Explanations](./explanation.md) (understanding-oriented)
   - Explanation, or discussions, clarify and illuminate a particular topic. They
     broaden the documentation’s coverage of a topic. Explanations can equally

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -95,3 +95,25 @@ A commit should almost always be linked to a GitHub issue.
 For:
 https://github.com/org/repo/issues/123
 ```
+
+## Name a Git branch
+
+Here is the format we like to follow for branch names:
+
+```
+[initials]-[issue number]-[optional description]
+```
+
+For example, if your name is Ada Lovelace and the issue you're working on is
+#123 your branch name would be:
+
+```
+al-123
+```
+
+If you wanted to add an optional (short) description at the end, you could name
+it:
+
+```
+al-123-fix-foobar
+```


### PR DESCRIPTION
For:
https://github.com/ClinGen/stanford-affils/issues/69