### PR TITLE
feat: custom permissions selector CSS

### DIFF
--- a/doc/how-to.md
+++ b/doc/how-to.md
@@ -72,7 +72,9 @@ source of truth for environment variable keys.
 - Change the path for `AFFILS_DB_FILE` and placeholder values.
 
 ## Affiliation Service User Guides
-TBD link to documentation for Affiliation Service users on how to do specific tasks on the site.
+
+TBD link to documentation for Affiliation Service users on how to do specific
+tasks on the site.
 
 ## Contributing
 

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -40,10 +40,20 @@ class UserAdmin(BaseUserAdmin, ModelAdmin):
     add_form = UserCreationForm
     change_password_form = AdminPasswordChangeForm
 
+    class Media:
+        """Media styling for selector widget on User page"""
+
+        css = {"all": ("css/permissions.css",)}
+
 
 @admin.register(Group)
 class GroupAdmin(BaseGroupAdmin, ModelAdmin):
     """Register Unfold group admin for styling of Group page."""
+
+    class Media:
+        """Media styling for selector widget on Group page"""
+
+        css = {"all": ("css/permissions.css",)}
 
 
 class AffiliationForm(forms.ModelForm):
@@ -103,11 +113,13 @@ class CoordinatorInlineAdmin(TabularInline):
     model = Coordinator
     extra = 1
 
+
 class ApproverInlineAdmin(TabularInline):
     """Configure the approvers admin panel."""
 
     model = Approver
     extra = 1
+
 
 class SubmitterInlineAdmin(TabularInline):
     """Configure the clinvar submitter IDs admin panel."""

--- a/src/affiliations/static/css/permissions.css
+++ b/src/affiliations/static/css/permissions.css
@@ -1,0 +1,17 @@
+.selector {
+    width: fit-content;
+    max-width: 100%;
+}
+
+.selector select {
+    width: fit-content;
+    max-width: 100%;
+    height: 17.2em;
+}
+
+.selector-available, .selector-chosen {
+    float: left;
+    width: fit-content;
+    max-width: 100%;
+    text-align: center;
+}

--- a/src/affiliations/static/css/permissions.css
+++ b/src/affiliations/static/css/permissions.css
@@ -1,17 +1,28 @@
 .selector {
-    width: fit-content;
-    max-width: 100%;
+    width: max-content;
+    max-width: max-content;
+
 }
 
 .selector select {
-    width: fit-content;
-    max-width: 100%;
-    height: 17.2em;
+    width: max-content;
+    height: 20em;
 }
 
 .selector-available, .selector-chosen {
     float: left;
-    width: fit-content;
-    max-width: 100%;
+    width: max-content;
+    max-width: max-content;
     text-align: center;
+}
+
+#id_permissions_from.filtered, 
+#id_permissions_to.filtered,
+#id_user_permissions_from.filtered,
+#id_user_permissions_to.filtered,
+#id_groups_from.filtered,
+#id_groups_to.filtered {
+    width: max-content;
+    max-width: max-content;
+
 }


### PR DESCRIPTION
Description
- Fix some file formatting.
- Add custom CSS to override Group permission widget styling to make it more readable for users.
- Add reference to custom CSS in User and Group methods in ```admin.py```.

Issue Ticket Number and Link 
Related to Issue #95 

Checklist Remove any options that are not applicable 
[X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md). 
[X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers. 
[X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended. 
[X] I have thoroughly commented my code, especially in more complex areas. 
[X] I have updated any necessary documentation.

Screenshots / Recordings

Groups Permissions display before:
<img width="620" alt="Screenshot 2024-07-31 at 3 06 18 PM" src="https://github.com/user-attachments/assets/30e0d954-2d4f-49ce-8c0f-a2a544fd4a83">


Groups/Permissions display after:
<img width="813" alt="Screenshot 2024-08-02 at 10 28 47 AM" src="https://github.com/user-attachments/assets/31afaeb6-08e8-464b-9c02-ad9cc75bde4f">


Even at max-size, these selectors will not extend pass containing div:
<img width="938" alt="Screenshot 2024-08-02 at 10 34 08 AM" src="https://github.com/user-attachments/assets/71ccaf63-617e-492e-9e74-a5e4953881d2">


Also pertains to group permissions:
<img width="679" alt="Screenshot 2024-08-02 at 10 33 54 AM" src="https://github.com/user-attachments/assets/14a488a4-3e1d-473d-9879-50c594f215d1">
