### PR TITLE
feat: disable ability to delete affiliations

### DIFF
--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -71,6 +71,7 @@ class AffiliationForm(forms.ModelForm):
                     ("Applying", "Applying"),
                     ("Inactive", "Inactive"),
                     ("Retired", "Retired"),
+                    ("Archived", "Archived"),
                 ]
             ),
             "type": UnfoldAdminSelectWidget(

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -176,6 +176,11 @@ class AffiliationsAdmin(ModelAdmin):
             "members",
         ]
 
+    def has_delete_permission(self, request, obj=None):
+        """Disables the ability to delete an affiliation."""
+        # pylint:disable=unused-argument
+        return False
+
 
 # Add models we want to be able to edit in the admin interface.
 admin.site.register(Affiliation, AffiliationsAdmin)
@@ -184,3 +189,6 @@ admin.site.register(Affiliation, AffiliationsAdmin)
 admin.site.site_title = "Affils Service"
 admin.site.site_header = "Affiliation Service Panel"
 admin.site.index_title = "Welcome to the ClinGen Affiliation Service Portal"
+
+# Disables the ability to bulk delete on the Affiliations Service.
+admin.site.disable_action("delete_selected")

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -159,7 +159,7 @@ UNFOLD = {
 # django-admin-logs
 
 # By default, Django creates log entries with the message “No fields changed”
-# when an unchanged object is saved in the admin interface. The below prevents 
+# when an unchanged object is saved in the admin interface. The below prevents
 # such log entries from being created.
 
 DJANGO_ADMIN_LOGS_IGNORE_UNCHANGED = True


### PR DESCRIPTION
Description
- Disable ability to bulk delete Affiliations, Groups, and Users sitewide.
- Disable ability to delete affiliations for all users
- Add "Archive" to ```Status``` to replace delete functionality.

Issue Ticket Number and Link 
Related to #112 

Checklist
 Remove any options that are not applicable
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.


Screenshots / Recordings

Cannot bulk delete:
<img width="647" alt="Screenshot 2024-08-07 at 3 25 08 PM" src="https://github.com/user-attachments/assets/5d94edfe-eb57-458d-bb31-bdf13a9b2c00">

Cannot delete an affiliation:
<img width="1307" alt="Screenshot 2024-08-07 at 3 25 16 PM" src="https://github.com/user-attachments/assets/4e00463e-b166-400f-838d-05fff189372f">

Archived Status:
<img width="228" alt="Screenshot 2024-08-07 at 3 40 11 PM" src="https://github.com/user-attachments/assets/accea4ec-1544-4d2c-9133-de41d85de07a">
