### PR TITLE
feat: update validation errors

### DIFF
--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -75,7 +75,8 @@ class AffiliationForm(forms.ModelForm):
             ),
             "type": UnfoldAdminSelectWidget(
                 choices=[
-                    ("Variant Curation Expert Panel", "Variant Curation Expert Panel"),
+                    ("Variant Curation Expert Panel",
+                     "Variant Curation Expert Panel"),
                     ("Gene Curation Expert Panel", "Gene Curation Expert Panel"),
                     ("Independent Curation Group", "Independent Curation Group"),
                 ]
@@ -90,7 +91,8 @@ class AffiliationForm(forms.ModelForm):
                     ("Immunology", "Immunology"),
                     ("Inborn Errors of Metabolism", "Inborn Errors of Metabolism"),
                     ("Kidney Disease", "Kidney Disease"),
-                    ("Neurodevelopmental Disorders", "Neurodevelopmental Disorders"),
+                    ("Neurodevelopmental Disorders",
+                     "Neurodevelopmental Disorders"),
                     ("Neurological Disorders", "Neurological Disorders"),
                     ("Ocular", "Ocular"),
                     ("Other", "Other"),
@@ -159,7 +161,8 @@ class AffiliationsAdmin(ModelAdmin):
         "type",
         "clinical_domain_working_group",
     ]
-    inlines = [CoordinatorInlineAdmin, ApproverInlineAdmin, SubmitterInlineAdmin]
+    inlines = [CoordinatorInlineAdmin,
+               ApproverInlineAdmin, SubmitterInlineAdmin]
 
     def get_readonly_fields(self, request, obj=None):
         """Fields that are editable upon creation, afterwards, are read only"""

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -117,6 +117,8 @@ class AffiliationForm(forms.ModelForm):
         if affil_id is None or full_name is None:
             # Allow Django to handle require field validation error.
             pass
+        if self.instance.pk is not None:
+            return
         if Affiliation.objects.filter(
             affiliation_id=affil_id, expert_panel_id=ep_id
         ).exists():

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -75,8 +75,7 @@ class AffiliationForm(forms.ModelForm):
             ),
             "type": UnfoldAdminSelectWidget(
                 choices=[
-                    ("Variant Curation Expert Panel",
-                     "Variant Curation Expert Panel"),
+                    ("Variant Curation Expert Panel", "Variant Curation Expert Panel"),
                     ("Gene Curation Expert Panel", "Gene Curation Expert Panel"),
                     ("Independent Curation Group", "Independent Curation Group"),
                 ]
@@ -91,8 +90,7 @@ class AffiliationForm(forms.ModelForm):
                     ("Immunology", "Immunology"),
                     ("Inborn Errors of Metabolism", "Inborn Errors of Metabolism"),
                     ("Kidney Disease", "Kidney Disease"),
-                    ("Neurodevelopmental Disorders",
-                     "Neurodevelopmental Disorders"),
+                    ("Neurodevelopmental Disorders", "Neurodevelopmental Disorders"),
                     ("Neurological Disorders", "Neurological Disorders"),
                     ("Ocular", "Ocular"),
                     ("Other", "Other"),
@@ -161,8 +159,7 @@ class AffiliationsAdmin(ModelAdmin):
         "type",
         "clinical_domain_working_group",
     ]
-    inlines = [CoordinatorInlineAdmin,
-               ApproverInlineAdmin, SubmitterInlineAdmin]
+    inlines = [CoordinatorInlineAdmin, ApproverInlineAdmin, SubmitterInlineAdmin]
 
     def get_readonly_fields(self, request, obj=None):
         """Fields that are editable upon creation, afterwards, are read only"""

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -156,7 +156,7 @@ class AffiliationForm(forms.ModelForm):
                         "Please include a valid Expert Panel ID."
                     ),
                 )
-            if affil_id - 10000 != affil_id - 40000:
+            if affil_id - 10000 != ep_id - 40000:
                 self.add_error(
                     None,
                     ValidationError(
@@ -172,7 +172,7 @@ class AffiliationForm(forms.ModelForm):
                         "Please include a valid Expert Panel ID."
                     ),
                 )
-            if affil_id - 10000 != affil_id - 50000:
+            if affil_id - 10000 != ep_id - 50000:
                 self.add_error(
                     None,
                     ValidationError(

--- a/src/affiliations/models.py
+++ b/src/affiliations/models.py
@@ -2,7 +2,6 @@
 
 # Third-party dependencies:
 from django.db import models
-from django.core.exceptions import ValidationError
 
 
 class Affiliation(models.Model):
@@ -41,55 +40,6 @@ class Affiliation(models.Model):
     def __str__(self):
         """Provide a string representation of an affiliation."""
         return f"Affiliation {self.affiliation_id} {self.full_name}"
-
-    def clean(self):
-        if self.affiliation_id is None or self.full_name is None:
-            # Allow Django to handle require field validation error.
-            pass
-        else:
-            if Affiliation.objects.filter(
-                affiliation_id=self.affiliation_id, expert_panel_id=self.expert_panel_id
-            ).exists():
-                raise ValidationError(
-                    """This Affiliation ID and Expert Panel ID already exist."""
-                )
-            if (
-                self.type == "Independent Curation Group"
-                and self.expert_panel_id is not None
-            ):
-                raise ValidationError(
-                    """If type Independent Curation Group is selected, Expert Panel
-                    ID must be left blank."""
-                )
-            if self.affiliation_id < 10000 or self.affiliation_id >= 20000:
-                raise ValidationError(
-                    """Valid Affiliation ID's should be in the 10000 number range.
-                    Please include a valid Affiliation ID."""
-                )
-            if self.type == "Gene Curation Expert Panel":
-                if self.expert_panel_id is None or (
-                    self.expert_panel_id < 40000 or self.expert_panel_id >= 50000
-                ):
-                    raise ValidationError(
-                        """Valid GCEP ID's should be in the 40000 number range. 
-                        Please include a valid Expert Panel ID."""
-                    )
-                if self.affiliation_id - 10000 != self.expert_panel_id - 40000:
-                    raise ValidationError(
-                        """The Affiliation ID and Expert Panel ID do not match."""
-                    )
-            if self.type == "Variant Curation Expert Panel":
-                if self.expert_panel_id is None or (
-                    self.expert_panel_id < 50000 or self.expert_panel_id >= 60000
-                ):
-                    raise ValidationError(
-                        """Valid VCEP ID's should be in the  50000 number range. 
-                        Please include a valid Expert Panel ID."""
-                    )
-                if self.affiliation_id - 10000 != self.expert_panel_id - 50000:
-                    raise ValidationError(
-                        """The Affiliation ID and Expert Panel ID do not match."""
-                    )
 
 
 class Coordinator(models.Model):

--- a/src/affiliations/models.py
+++ b/src/affiliations/models.py
@@ -47,6 +47,12 @@ class Affiliation(models.Model):
             # Allow Django to handle require field validation error.
             pass
         else:
+            if Affiliation.objects.filter(
+                affiliation_id=self.affiliation_id, expert_panel_id=self.expert_panel_id
+            ).exists():
+                raise ValidationError(
+                    """This Affiliation ID and Expert Panel ID already exist."""
+                )
             if (
                 self.type == "Independent Curation Group"
                 and self.expert_panel_id is not None
@@ -68,6 +74,10 @@ class Affiliation(models.Model):
                         """Valid GCEP ID's should be in the 40000 number range. 
                         Please include a valid Expert Panel ID."""
                     )
+                if self.affiliation_id - 10000 != self.expert_panel_id - 40000:
+                    raise ValidationError(
+                        """The Affiliation ID and Expert Panel ID do not match."""
+                    )
             if self.type == "Variant Curation Expert Panel":
                 if self.expert_panel_id is None or (
                     self.expert_panel_id < 50000 or self.expert_panel_id >= 60000
@@ -75,6 +85,10 @@ class Affiliation(models.Model):
                     raise ValidationError(
                         """Valid VCEP ID's should be in the  50000 number range. 
                         Please include a valid Expert Panel ID."""
+                    )
+                if self.affiliation_id - 10000 != self.expert_panel_id - 50000:
+                    raise ValidationError(
+                        """The Affiliation ID and Expert Panel ID do not match."""
                     )
 
 

--- a/src/affiliations/tests.py
+++ b/src/affiliations/tests.py
@@ -1,12 +1,16 @@
 """Tests for the affiliations service."""
 
 # Third-party dependencies:
+from unittest import mock
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 from rest_framework.test import APIRequestFactory
+
+# In-house code:
 from affiliations.views import AffiliationsList
 from affiliations.views import AffiliationsDetail
 from affiliations.models import Affiliation, Coordinator, Approver, Submitter
+from affiliations.admin import AffiliationForm
 
 
 class AffiliationsViewsBaseTestCase(TestCase):
@@ -164,9 +168,19 @@ class TestInvalidAffilCreateForm(TestCase):
             **cls.invalid_affil_id_affiliation
         )
 
-    def test_response(self):
-        """Make sure we are triggering the ValidationError"""
-        self.assertRaises(ValidationError, self.invalid_affil_id_affil.clean)
+    @mock.patch("affiliations.admin.AffiliationForm.add_error")
+    def test_response(self, mock_add_error):
+        """Make sure we are triggering the add_error function in clean method"""
+        invalid_affil = AffiliationForm(self.invalid_affil_id_affil)
+        invalid_affil.cleaned_data = self.invalid_affil_id_affiliation
+        invalid_affil.clean()
+        calls = [
+            mock.call(
+                None,
+                ValidationError("The Affiliation ID and Expert Panel ID do not match."),
+            )
+        ]
+        mock_add_error.assert_has_calls(calls)
 
 
 class TestInvalidGCEPCreateForm(TestCase):
@@ -191,9 +205,22 @@ class TestInvalidGCEPCreateForm(TestCase):
             **cls.invalid_gcep_id_affiliation
         )
 
-    def test_response(self):
-        """Make sure we are triggering the ValidationError"""
-        self.assertRaises(ValidationError, self.invalid_gcep_id_affil.clean)
+    @mock.patch("affiliations.admin.AffiliationForm.add_error")
+    def test_response(self, mock_add_error):
+        """Make sure we are triggering the add_error function in clean method"""
+        gcep_affil = AffiliationForm(self.invalid_gcep_id_affil)
+        gcep_affil.cleaned_data = self.invalid_gcep_id_affiliation
+        gcep_affil.clean()
+        calls = [
+            mock.call(
+                "expert_panel_id",
+                ValidationError(
+                    "Valid GCEP ID's should be in the 40000 number range. "
+                    "Please include a valid Expert Panel ID."
+                ),
+            )
+        ]
+        mock_add_error.assert_has_calls(calls)
 
 
 class TestInvalidVCEPCreateForm(TestCase):
@@ -219,9 +246,22 @@ class TestInvalidVCEPCreateForm(TestCase):
             **cls.invalid_vcep_id_affiliation
         )
 
-    def test_response(self):
-        """Make sure we are triggering the ValidationError"""
-        self.assertRaises(ValidationError, self.invalid_vcep_id_affil.clean)
+    @mock.patch("affiliations.admin.AffiliationForm.add_error")
+    def test_response(self, mock_add_error):
+        """Make sure we are triggering the add_error function in clean method"""
+        vcep_affil = AffiliationForm(self.invalid_vcep_id_affil)
+        vcep_affil.cleaned_data = self.invalid_vcep_id_affiliation
+        vcep_affil.clean()
+        calls = [
+            mock.call(
+                "expert_panel_id",
+                ValidationError(
+                    "Valid VCEP ID's should be in the  50000 number range. "
+                    "Please include a valid Expert Panel ID."
+                ),
+            )
+        ]
+        mock_add_error.assert_has_calls(calls)
 
 
 class TestInvalidTypeAndIDCreateForm(TestCase):
@@ -248,9 +288,22 @@ class TestInvalidTypeAndIDCreateForm(TestCase):
             **cls.invalid_type_and_id_affiliation
         )
 
-    def test_response(self):
-        """Make sure we are triggering the ValidationError"""
-        self.assertRaises(ValidationError, self.invalid_type_and_id_affil.clean)
+    @mock.patch("affiliations.admin.AffiliationForm.add_error")
+    def test_response(self, mock_add_error):
+        """Make sure we are triggering the add_error function in clean method"""
+        invalid_type = AffiliationForm(self.invalid_type_and_id_affil)
+        invalid_type.cleaned_data = self.invalid_type_and_id_affiliation
+        invalid_type.clean()
+        calls = [
+            mock.call(
+                "expert_panel_id",
+                ValidationError(
+                    "If type Independent Curation Group is selected, "
+                    "Expert Panel ID must be left blank."
+                ),
+            )
+        ]
+        mock_add_error.assert_has_calls(calls)
 
 
 class AffiliationsListTestCase(AffiliationsViewsBaseTestCase):

--- a/src/affiliations/tests.py
+++ b/src/affiliations/tests.py
@@ -306,6 +306,45 @@ class TestInvalidTypeAndIDCreateForm(TestCase):
         mock_add_error.assert_has_calls(calls)
 
 
+class TestInvalidAffilandExpertPanelMatchCreateForm(TestCase):
+    """A test class for testing validation error on Affiliation ID
+    and Expert Panel match."""
+
+    @classmethod
+    def test_invalid_matching_ids_creation(cls):
+        """Attempting to seed the test database with some test data, then make
+        sure we are triggering the ValidationError"""
+
+        cls.invalid_matching_ids_affiliation = {
+            "affiliation_id": 14285,
+            "expert_panel_id": 54284,
+            "full_name": "Affil and EP ID Don't Match",
+            "abbreviated_name": "Invalid Matching IDs",
+            "status": "Active",
+            "type": "Variant Curation Expert Panel",
+            "clinical_domain_working_group": "Somatic Cancer",
+            "members": "Piplup, Toxicroak, Weavile",
+        }
+
+        cls.invalid_matching_ids_affil = Affiliation.objects.create(
+            **cls.invalid_matching_ids_affiliation
+        )
+
+    @mock.patch("affiliations.admin.AffiliationForm.add_error")
+    def test_response(self, mock_add_error):
+        """Make sure we are triggering the add_error function in clean method"""
+        invalid_matching_ids = AffiliationForm(self.invalid_matching_ids_affil)
+        invalid_matching_ids.cleaned_data = self.invalid_matching_ids_affiliation
+        invalid_matching_ids.clean()
+        calls = [
+            mock.call(
+                None,
+                ValidationError("The Affiliation ID and Expert Panel ID do not match."),
+            )
+        ]
+        mock_add_error.assert_has_calls(calls)
+
+
 class AffiliationsListTestCase(AffiliationsViewsBaseTestCase):
     """Test the affiliations list view."""
 

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -159,7 +159,7 @@ UNFOLD = {
 # django-admin-logs
 
 # By default, Django creates log entries with the message “No fields changed”
-# when an unchanged object is saved in the admin interface. The below prevents 
+# when an unchanged object is saved in the admin interface. The below prevents
 # such log entries from being created.
 
 DJANGO_ADMIN_LOGS_IGNORE_UNCHANGED = True


### PR DESCRIPTION
Description
- Based on feedback, add two new validation errors:
> affiliation_id and expert_panel_id will always end in the same number ( example: 10025 and 40025 )
> We should validate if an affiliation_id and curation_panel_id combo exist in the DB. There should not be duplicates.
- Move clean method from models.py to admin.py as per the django documentation that this should be related to the form, rather than the model.
- Change how validation errors are displayed. Previously, once one validation error was triggered, the clean method stopped. The desired behavior was that all validation errors are displayed to the user. This was changed utilizing the add_error method.
- Some validation errors are displayed at the top of the screen, while others are displayed next to their input box.
- Update validation error messages.
- Update validation tests.

Issue Ticket Number and Link 
Related to #112 

Checklist
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.

Screenshots / Recordings

Two validation errors displayed:
<img width="620" alt="Screenshot 2024-08-12 at 2 41 56 PM" src="https://github.com/user-attachments/assets/f3892a96-bf49-45b0-bf9d-bfe15a68bb52">
