### PR TITLE
feat: superuser able to edit "read-only" fields

### DIFF
--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -233,16 +233,20 @@ class AffiliationsAdmin(ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
         """Fields that are editable upon creation, afterwards, are read only"""
-        # pylint:disable=unused-argument
-        if obj is None:
-            return [
-                "members",
-            ]
+        # If the affiliation has not been created (is new) only return Members as read only
+        # Otherwise, check to see if user has the staff role and is not a superuser,
+        # Then return the full list of read only fields.
+        # This allows superusers to edit these fields in the case of affiliation creation error.
+        if obj is not None:
+            if request.user.is_staff and not request.user.is_superuser:
+                return [
+                    "affiliation_id",
+                    "expert_panel_id",
+                    "type",
+                    "clinical_domain_working_group",
+                    "members",
+                ]
         return [
-            "affiliation_id",
-            "expert_panel_id",
-            "type",
-            "clinical_domain_working_group",
             "members",
         ]
 

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -229,6 +229,16 @@ class AffiliationsAdmin(ModelAdmin):
     ]
     list_filter_submit = True  # Submit button at the bottom of filter tab.
     list_fullwidth = True
+    fields = (
+        "affiliation_id",
+        "expert_panel_id",
+        "type",
+        "full_name",
+        "abbreviated_name",
+        "status",
+        "clinical_domain_working_group",
+        "members",
+    )
     inlines = [CoordinatorInlineAdmin, ApproverInlineAdmin, SubmitterInlineAdmin]
 
     def get_readonly_fields(self, request, obj=None):

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -195,12 +195,16 @@ class AffiliationsAdmin(ModelAdmin):
     """Configure the affiliations admin panel."""
 
     form = AffiliationForm
+
+    # Controls which fields are searchable via the search bar.
     search_fields = [
         "affiliation_id",
         "expert_panel_id",
         "full_name",
         "abbreviated_name",
     ]
+
+    # Controls what fields are listed in overview header.
     # pylint:disable=duplicate-code
     list_display = [
         "affiliation_id",
@@ -212,6 +216,7 @@ class AffiliationsAdmin(ModelAdmin):
         "clinical_domain_working_group",
     ]
 
+    # Controls what columns are "clickable" to enter detailed view.
     # pylint:disable=duplicate-code
     list_display_links = [
         "affiliation_id",
@@ -222,6 +227,8 @@ class AffiliationsAdmin(ModelAdmin):
         "type",
         "clinical_domain_working_group",
     ]
+
+    # Controls what fields can be filtered on.
     list_filter = [
         ("status", MultipleChoicesDropdownFilter),
         ("type", ChoicesDropdownFilter),
@@ -229,6 +236,8 @@ class AffiliationsAdmin(ModelAdmin):
     ]
     list_filter_submit = True  # Submit button at the bottom of filter tab.
     list_fullwidth = True
+
+    # Controls the visual order of fields listed.
     fields = (
         "affiliation_id",
         "expert_panel_id",


### PR DESCRIPTION
Description
- Refactor the "read-only" fields so that superusers can edit these fields, if needed, and for non-superusers/staff 
these fields are read-only. This will be useful in the case that an affiliation is created accidentally with the incorrect information. A request can be made to a superuser to edit this information to reflect the accurate/correct information.

Issue Ticket Number and Link 
Related to and closes #112

Checklist
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.

Screenshots / Recordings
Superuser view:
![Screenshot 2024-08-14 at 10 23 09 AM](https://github.com/user-attachments/assets/2573117b-5527-4b9c-9164-72d62cf24f0a)

Staff View:
(greyed out fields are read-only)
![Screenshot 2024-08-14 at 10 22 56 AM](https://github.com/user-attachments/assets/df1bd6a6-3918-43e1-a80f-a05e1ed1852c)
