### PR TITLE
feat: Add CSRF trusted origin

### DIFF
--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -36,6 +36,9 @@ DEBUG = False
 
 ALLOWED_HOSTS = ["affils.clinicalgenome.org"]
 
+CSRF_TRUSTED_ORIGINS = ["https://affils.clinicalgenome.org"]
+
+
 INSTALLED_APPS = [
     "unfold",
     "unfold.contrib.filters",


### PR DESCRIPTION
Add CSRF_TRUSTED_ORIGINS value in settings.py based on this documentation:
-https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
Found this django forums question very similar to this issue and this is how it was recommended to solve:
- https://forum.djangoproject.com/t/csrf-verification-error-for-django-admin-login/11785

After making this change, was able to log into Django Admin without the error.

<img width="450" alt="Screenshot 2024-08-29 at 1 50 41 PM" src="https://github.com/user-attachments/assets/11b7064e-0141-4c7e-91c2-9f1ed0ce4598">
