### PR TITLE
feat: add coordinator name and email to overview

### DIFF
--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -206,6 +206,8 @@ class AffiliationsAdmin(ModelAdmin):
         "expert_panel_id",
         "full_name",
         "abbreviated_name",
+        "coordinators__coordinator_name",
+        "coordinators__coordinator_email",
     ]
 
     # Controls what fields are listed in overview header.
@@ -218,6 +220,8 @@ class AffiliationsAdmin(ModelAdmin):
         "status",
         "type",
         "clinical_domain_working_group",
+        "get_coordinator_names",
+        "get_coordinator_emails",
     ]
 
     # Controls what columns are "clickable" to enter detailed view.
@@ -230,7 +234,35 @@ class AffiliationsAdmin(ModelAdmin):
         "status",
         "type",
         "clinical_domain_working_group",
+        "get_coordinator_names",
+        "get_coordinator_emails",
     ]
+
+    @admin.display(
+        description="Coordinator Name", ordering="coordinators__coordinator_name"
+    )
+    def get_coordinator_names(self, obj):
+        """Query coordinator names and return list of names"""
+        coordinators = Coordinator.objects.filter(affiliation_id=obj.pk).values_list(
+            "coordinator_name", flat=True
+        )
+        coordinator_names = []
+        for name in coordinators:
+            coordinator_names.append(name)
+        return coordinator_names
+
+    @admin.display(
+        description="Coordinator Email",
+    )
+    def get_coordinator_emails(self, obj):
+        """Query coordinator emails and return list of emails"""
+        coordinators = Coordinator.objects.filter(affiliation_id=obj.pk).values_list(
+            "coordinator_email", flat=True
+        )
+        coordinator_emails = []
+        for email in coordinators:
+            coordinator_emails.append(email)
+        return coordinator_emails
 
     # Controls what fields can be filtered on.
     list_filter = [


### PR DESCRIPTION
Description
- Add coordinator name and email to list_display.
- Add coordinator name and email to list_display_links to make text clickable for users.
- Add coordinator name and email to search_fields so users can search by those fields.

Issue Ticket Number and Link 
Closes #141 

Checklist
 Remove any options that are not applicable
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.

Screenshots / Recordings
<img width="1410" alt="Screenshot 2024-09-24 at 3 50 27 PM" src="https://github.com/user-attachments/assets/b9cde1f9-cf15-4c48-8711-44da273d9bcd">
<img width="1438" alt="Screenshot 2024-09-24 at 3 50 37 PM" src="https://github.com/user-attachments/assets/88d85270-257e-44bc-a8a1-c7eb5e586e6b">
