### PR TITLE
fix: hide object text

### DIFF
--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -324,6 +324,10 @@ class AffiliationsAdmin(ModelAdmin):
             context["media"] += forms.Media(
                 js=["js/admin_hide_attribute_new.js"],
             )
+        else:
+            context["media"] += forms.Media(
+                css={"all": ("css/hide_admin_original.css",)},
+            )
         return super().render_change_form(request, context, *args, obj=None, **kwargs)
 
 

--- a/src/affiliations/static/css/hide_admin_original.css
+++ b/src/affiliations/static/css/hide_admin_original.css
@@ -1,0 +1,7 @@
+td.original {
+    visibility: hidden
+  }
+  
+  .inline-group .tabular tr.has_original td {
+      padding-top: 0px;
+  }

--- a/src/affiliations/static/css/hide_admin_original.css
+++ b/src/affiliations/static/css/hide_admin_original.css
@@ -1,7 +1,10 @@
+/* This stylesheet is used to omit object names in the tabular inline 
+view on the edit/view page in Django Admin. */
+
 td.original {
     visibility: hidden
   }
   
-  .inline-group .tabular tr.has_original td {
+.inline-group .tabular tr.has_original td {
       padding-top: 0px;
   }


### PR DESCRIPTION
Description
- use CSS to hide object text in admin edit form

Issue Ticket Number and Link 
N/A

Checklist
 Remove any options that are not applicable
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.

Screenshots / Recordings
With CSS applied:
<img width="252" alt="Screenshot 2024-11-14 at 10 07 20 AM" src="https://github.com/user-attachments/assets/82043bf8-8239-4180-b2fe-0b115351a6eb">

Without CSS applied:
<img width="236" alt="Screenshot 2024-11-14 at 10 08 07 AM" src="https://github.com/user-attachments/assets/58155af7-c740-4a12-a90d-e8c398e2a77c">
