### PR TITLE
feat: add API endpoints for current JSON format

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ env:
   AFFILS_AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
   AFFILS_AWS_REGION: ${{ secrets.AWS_REGION }}
   AFFILS_AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+  DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
 permissions:
   contents: read
 jobs:

--- a/src/affiliations/tests.py
+++ b/src/affiliations/tests.py
@@ -150,6 +150,67 @@ class AffiliationsViewsBaseTestCase(TestCase):
             clinvar_submitter_id="99",
         )
 
+    def test_should_be_able_to_view_list_of_affiliations(self):
+        """Make sure we are able to view our list of affiliations."""
+        factory = APIRequestFactory()
+        view = AffiliationsList.as_view()
+        request = factory.get("/database_list/")
+        response = view(request)
+        self.assertDictEqual(
+            response.data[0],
+            self.expected_success_affiliation,
+        )
+        self.assertDictEqual(
+            response.data[1],
+            self.expected_hoenn_affiliation,
+        )
+
+    def test_should_be_able_to_view_single_affiliation_detail(self):
+        """Make sure we are able to view a single affiliation's details."""
+        factory = APIRequestFactory()
+        view = AffiliationsDetail.as_view()
+        primary_key = 1
+        request = factory.get(f"/database_list/{primary_key}")
+        response = view(request, pk=primary_key)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertDictEqual(response.data, self.expected_success_affiliation)
+        primary_key = 2
+        request = factory.get(f"/database_list/{primary_key}")
+        response = view(request, pk=primary_key)
+        self.assertDictEqual(response.data, self.expected_hoenn_affiliation)
+
+    def test_detail_affiliation_json_call(self):
+        """Make sure the API response of a single affiliation is returned
+        in the original JSON format ."""
+        response = self.client.get("/api/affiliation_detail/?affil_id=10000")
+        self.assertEqual(
+            response.json(),
+            [
+                {
+                    "affiliation_id": 10000,
+                    "affiliation_fullname": "Test Success Result Affil",
+                    "subgroups": {
+                        "gene curation expert panel": {
+                            "id": 40000,
+                            "fullname": "Test Success Result Affil",
+                        }
+                    },
+                    "approver": [
+                        "Mew",
+                    ],
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_affiliation_json_call(self):
+        """Make sure the API response of all the affiliations in the db is
+        returned in the original JSON format ."""
+        response = self.client.get("/api/affiliations_list/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 2)
+
 
 class TestUserInputsIds(TestCase):
     """A test class for testing validation if a user passed in an affiliation ID
@@ -237,39 +298,3 @@ class TestAffiliationIDOutOfRange(TestCase):
             ),
         ]
         mock_add_error.assert_has_calls(calls)
-
-
-class AffiliationsListTestCase(AffiliationsViewsBaseTestCase):
-    """Test the affiliations list view."""
-
-    def test_should_be_able_to_view_list_of_affiliations(self):
-        """Make sure we are able to view our list of affiliations."""
-        factory = APIRequestFactory()
-        view = AffiliationsList.as_view()
-        request = factory.get("/")
-        response = view(request)
-        self.assertDictEqual(
-            response.data[0],
-            self.expected_success_affiliation,
-        )
-        self.assertDictEqual(
-            response.data[1],
-            self.expected_hoenn_affiliation,
-        )
-
-
-class AffiliationsDetailTestCase(AffiliationsViewsBaseTestCase):
-    """Test the affiliations details view."""
-
-    def test_should_be_able_to_view_single_affiliation_detail(self):
-        """Make sure we are able to view a single affiliation's details."""
-        factory = APIRequestFactory()
-        view = AffiliationsDetail.as_view()
-        primary_key = 1
-        request = factory.get(f"/{primary_key}")
-        response = view(request, pk=primary_key)
-        self.assertDictEqual(response.data, self.expected_success_affiliation)
-        primary_key = 2
-        request = factory.get(f"/{primary_key}")
-        response = view(request, pk=primary_key)
-        self.assertDictEqual(response.data, self.expected_hoenn_affiliation)

--- a/src/affiliations/urls.py
+++ b/src/affiliations/urls.py
@@ -9,8 +9,16 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from affiliations import views
 
 urlpatterns: list[URLResolver | URLPattern] = [
-    path("", views.AffiliationsList.as_view()),
-    path("<int:pk>/", views.AffiliationsDetail.as_view()),
+    path("database_list/", views.AffiliationsList.as_view()),
+    path("database_list/<int:pk>/", views.AffiliationsDetail.as_view()),
+    path(
+        "affiliations_list/",
+        views.affiliations_list_json_format,
+    ),
+    path(
+        "affiliation_detail/",
+        views.affiliation_detail_json_format,
+    ),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/src/affiliations/views.py
+++ b/src/affiliations/views.py
@@ -1,11 +1,12 @@
 """Views for the affiliations service."""
 
 # Third-party dependencies:
-from rest_framework import generics
-from rest_framework import permissions
+from rest_framework import generics, permissions
+from rest_framework.decorators import api_view
+from django.http import JsonResponse
 
 # In-house code:
-from affiliations.models import Affiliation
+from affiliations.models import Affiliation, Approver
 from affiliations.serializers import AffiliationSerializer
 
 
@@ -23,3 +24,47 @@ class AffiliationsDetail(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     queryset = Affiliation.objects.all()
     serializer_class = AffiliationSerializer
+
+
+@api_view(["GET"])
+def affiliations_list_json_format(request):  # pylint: disable=unused-argument
+    """List all affiliations in old JSON format."""
+    affils_queryset = Affiliation.objects.filter(is_deleted=False).values()
+    response_obj = {}
+    for affil in affils_queryset:
+        affil_type = affil["type"].lower()
+        if affil["affiliation_id"] not in response_obj:
+            old_json_format = {
+                "affiliation_id": affil["affiliation_id"],
+                "affiliation_fullname": affil["full_name"],
+                "subgroups": {
+                    affil_type: {
+                        "id": affil["expert_panel_id"],
+                        "fullname": affil["full_name"],
+                    },
+                },
+                "approver": [],
+            }
+            response_obj[affil["affiliation_id"]] = old_json_format
+
+        elif affil_type not in response_obj[affil["affiliation_id"]]["subgroups"]:
+            response_obj[affil["affiliation_id"]]["affiliation_fullname"] = (
+                response_obj[affil["affiliation_id"]]["affiliation_fullname"]
+                + "/"
+                + affil["type"]
+            )
+            response_obj[affil["affiliation_id"]]["subgroups"][affil_type] = {
+                affil_type: {
+                    "id": affil["expert_panel_id"],
+                    "fullname": affil["full_name"],
+                },
+            }
+        approvers_queryset = Approver.objects.filter(
+            affiliation_id=affil["id"]
+        ).values_list("approver_name", flat=True)
+        for name in approvers_queryset:
+            response_obj[affil["affiliation_id"]]["approver"].append(name)
+
+    return JsonResponse(list(response_obj.values()), status=200, safe=False)
+
+

--- a/src/affiliations/views.py
+++ b/src/affiliations/views.py
@@ -68,3 +68,46 @@ def affiliations_list_json_format(request):  # pylint: disable=unused-argument
     return JsonResponse(list(response_obj.values()), status=200, safe=False)
 
 
+@api_view(["GET"])
+def affiliation_detail_json_format(request):
+    """List specific affiliation in old JSON format."""
+    affil_id = request.GET.get("affil_id")
+    affils_queryset = Affiliation.objects.filter(
+        affiliation_id=affil_id, is_deleted=False
+    ).values()
+    response_obj = {}
+    for affil in affils_queryset:
+        affil_type = affil["type"].lower()
+        if affil["affiliation_id"] not in response_obj:
+            old_json_format = {
+                "affiliation_id": affil["affiliation_id"],
+                "affiliation_fullname": affil["full_name"],
+                "subgroups": {
+                    affil_type: {
+                        "id": affil["expert_panel_id"],
+                        "fullname": affil["full_name"],
+                    },
+                },
+                "approver": [],
+            }
+            response_obj[affil["affiliation_id"]] = old_json_format
+
+        elif affil_type not in response_obj[affil["affiliation_id"]]["subgroups"]:
+            response_obj[affil["affiliation_id"]]["affiliation_fullname"] = (
+                response_obj[affil["affiliation_id"]]["affiliation_fullname"]
+                + "/"
+                + affil["full_name"]
+            )
+            response_obj[affil["affiliation_id"]]["subgroups"][affil_type] = {
+                affil_type: {
+                    "id": affil["expert_panel_id"],
+                    "fullname": affil["full_name"],
+                },
+            }
+        approvers_queryset = Approver.objects.filter(
+            affiliation_id=affil["id"]
+        ).values_list("approver_name", flat=True)
+        for name in approvers_queryset:
+            response_obj[affil["affiliation_id"]]["approver"].append(name)
+
+    return JsonResponse(list(response_obj.values()), status=200, safe=False)

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -6,9 +6,17 @@ https://docs.djangoproject.com/en/5.0/topics/http/urls/
 
 # Third-party dependencies:
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, reverse_lazy
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
-    path("", admin.site.urls),
+    path("", RedirectView.as_view(url=reverse_lazy("admin:index"))),
+    path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
+    path(
+        "api/",
+        include(
+            "affiliations.urls",
+        ),
+    ),
 ]


### PR DESCRIPTION
Description
- Add redirect to admin site. Admin as the base site was causing a conflict with the browsable API
- Add API path in main/urls.py
- Add API affiliations/url.py paths to provide current affiliation JSON file format.
- Change name of previous browsable API urls for clarity
- Add function to return all non-deleted affiliations in the current JSON file format.
- Add function to return specific non-deleted affiliation in the current JSON file format.


Tested this out using Postman.

Issue Ticket Number and Link 
A part of #185

Checklist
 Remove any options that are not applicable
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.

Screenshots / Recordings