### PR TITLE
feat: Add update affiliation by ep_id

### DIFF
--- a/doc/api_information.md
+++ b/doc/api_information.md
@@ -39,10 +39,20 @@ POST `affiliation/create/`
 - Returns a `400 Bad Request` on failure with error message of missing or
   invalid fields.
 
-PATCH `affiliation/<int:affiliation_id>/update/`
+PATCH `affiliation/update/affiliation_id/<int:affiliation_id>/`
 
-- Updates an existing Affiliation. This endpoint generates and returns a
-  `200 OK` and full changed affiliation on success.
+- Updates an existing Affiliation by Affiliation ID. This endpoint generates and
+  returns a `200 OK` and full changed affiliation on success.
+
+- Returns a `400 Bad Request` on failure with error message of missing or
+  invalid fields.
+
+- Returns a `404 Not Found` on failure with error message.
+
+PATCH `affiliation/update/expert_panel_id/<int:expert_panel_id>/`
+
+- Updates an existing Affiliation by Expert Panel ID. This endpoint generates
+  and returns a `200 OK` and full changed affiliation on success.
 
 - Returns a `400 Bad Request` on failure with error message of missing or
   invalid fields.
@@ -141,10 +151,10 @@ Acceptable `status` values:
 - RETIRED
 - ARCHIVED
 
-## PATCH affiliation/<int:affiliation_id>/update/ Endpoint Details:
+## PATCH affiliation/update/affiliation_id/<int:affiliation_id>/ and affiliation/update/expert_panel_id/<int:expert_panel_id>/Endpoint Details:
 
-The affiliation_id in the URL is the only required field. In request, only the
-values that need to be updated should be included.
+The ID in the URL is the only required field. In request, only the values that
+need to be updated should be included.
 
 #### Successful Response:
 
@@ -179,7 +189,7 @@ Example:
 {
     "error": "Request Failed",
     "details": {
-        "detail": "No Affiliation matches the given query."
+        "detail": "Affiliation with the provided affiliation_id was not found."
     }
 }
 ```
@@ -338,7 +348,6 @@ Example:
     }
 }
 ```
-
 
 ### URLS
 

--- a/src/affiliations/urls.py
+++ b/src/affiliations/urls.py
@@ -24,7 +24,11 @@ urlpatterns: list[URLResolver | URLPattern] = [
         views.create_affiliation,
     ),
     path(
-        "affiliation/<int:affiliation_id>/update/",
+        "affiliation/update/affiliation_id/<int:affiliation_id>/",
+        views.AffiliationUpdateView.as_view(),
+    ),
+    path(
+        "affiliation/update/expert_panel_id/<int:expert_panel_id>/",
         views.AffiliationUpdateView.as_view(),
     ),
     path(

--- a/src/affiliations/views.py
+++ b/src/affiliations/views.py
@@ -57,12 +57,37 @@ class AffiliationsDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class AffiliationUpdateView(generics.RetrieveUpdateAPIView):
-    """Update editable affiliation data, return all affiliation information."""
+    """Update editable affiliation data, return all affiliation information.
+    This view supports lookup by either `affiliation_id` or `expert_panel_id`
+    (only one should be provided in the URL).
+    """
 
     permission_classes = [HasAPIKey | IsAuthenticated]
     queryset = Affiliation.objects.all()
     serializer_class = AffiliationSerializer
-    lookup_field = "affiliation_id"
+
+    def get_object(self):
+        """Retrieve Affiliation by either affiliation_id or expert_panel_id."""
+        affiliation_id = self.kwargs.get("affiliation_id")
+        expert_panel_id = self.kwargs.get("expert_panel_id")
+
+        if affiliation_id is not None:
+            try:
+                return Affiliation.objects.get(affiliation_id=affiliation_id)
+            except Affiliation.DoesNotExist as exc:
+                raise Http404(
+                    "Affiliation with the provided affiliation_id was not found."
+                ) from exc
+
+        if expert_panel_id is not None:
+            try:
+                return Affiliation.objects.get(expert_panel_id=expert_panel_id)
+            except Affiliation.DoesNotExist as exc:
+                raise Http404(
+                    "Affiliation with the provided expert_panel_id was not found."
+                ) from exc
+
+        raise Http404("An affiliation_id or expert_panel_id must be provided.")
 
 
 class CDWGCreateView(generics.CreateAPIView):


### PR DESCRIPTION
Description
UNC communicate that they primarily use expert_panel_ids, so I added a path to update an affiliation by expert_panel_id.

- Add update affiliation by ep_id path
- Add views.py logic to handle either affiliation id or ep id
- Update docs
- Update tests

Issue Ticket Number and Link 
N/A

Checklist
 Remove any options that are not applicable
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.