### PR TITLE
Fix: ID Validation checks.

### DIFF
--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import User, Group
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin
 from django.utils.translation import gettext_lazy as _
-from django.core.exceptions import ValidationError
 from django.db import transaction
 from rest_framework_api_key.models import APIKey
 from rest_framework_api_key.admin import APIKeyModelAdmin
@@ -47,7 +46,7 @@ from affiliations.utils import (
     check_duplicate_affiliation_uuid,
     validate_type_and_uuid,
     validate_id_duplicates,
-    validate_id_suffix_match
+    validate_id_suffix_match,
 )
 from .models import CustomAPIKey
 

--- a/src/affiliations/admin.py
+++ b/src/affiliations/admin.py
@@ -46,6 +46,8 @@ from affiliations.utils import (
     validate_unique_cdwg_name,
     check_duplicate_affiliation_uuid,
     validate_type_and_uuid,
+    validate_id_duplicates,
+    validate_id_suffix_match
 )
 from .models import CustomAPIKey
 
@@ -193,21 +195,10 @@ class AffiliationForm(forms.ModelForm):
             set_expert_panel_id(cleaned_data)
 
         uuid_val = self.cleaned_data.get("uuid")
-        generate_next_affiliation_id(cleaned_data)
         check_duplicate_affiliation_uuid(uuid_val, instance=self.instance)
         validate_type_and_uuid(cleaned_data)
-        # Check to see if the Affil and EP ID already exist in DB.
-        if (
-            Affiliation.objects.select_for_update()
-            .filter(
-                affiliation_id=cleaned_data.get("affiliation_id"),
-                expert_panel_id=cleaned_data.get("expert_panel_id"),
-            )
-            .exists()
-        ):
-            raise ValidationError(
-                "An affiliation with this Affiliation ID with this Expert Panel ID already exist."
-            )
+        validate_id_duplicates(cleaned_data, instance=self.instance)
+        validate_id_suffix_match(cleaned_data)
         return cleaned_data
 
 

--- a/src/affiliations/utils.py
+++ b/src/affiliations/utils.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ValidationError
 from affiliations.models import Affiliation, ClinicalDomainWorkingGroup
 
 
-
 VCEP_BASE = 50000
 GCEP_BASE = 40000
 AFFIL_BASE = 10000
@@ -202,6 +201,4 @@ def validate_id_suffix_match(
     ep_suffix = ep_id % 1000
 
     if affil_suffix != ep_suffix:
-        raise ValidationError(
-            f"The ID suffix must match: got {affil_id} and {ep_id}."
-        )
+        raise ValidationError(f"The ID suffix must match: got {affil_id} and {ep_id}.")


### PR DESCRIPTION
Description
- Remove stale logic from admin.py to validate Affiliation and EP IDs
- Add additional logic into utils.py
- TO DO: Fix Affiliation EP 40173, Affiliation ID currently is 10178 but should be 10173. This can be fixed by a superuser. (This occurred because of a bug in the logic that would increment to the next affils ID available.)

Issue Ticket Number and Link 
Issue/Recommendation raised in PR #310, created and will close issue #330.
Checklist
 Remove any options that are not applicable
 [X ] I have reviewed the [how-to guide](https://github.com/ClinGen/stanford-affils/pull/how-to.md) and the [contributing file](https://github.com/ClinGen/stanford-affils/CONTRIBUTING.md).
 [X] I have run required [code checks](https://github.com/ClinGen/stanford-affils/pull/how-to.md#run-code-checks) and resolved any blockers.
 [X] I have created the necessary [tests](https://github.com/ClinGen/stanford-affils/src/app_test.py) to show my changes are effective and work as intended.
 [X] I have thoroughly commented my code, especially in more complex areas.
 [X] I have updated any necessary documentation.

Screenshots / Recordings